### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LibraryDirs = None
 Libraries = None
 BuildExtension = build_ext
 CompileArgs = ['-msse2', '-O2', '-fPIC', '-w']
-LinkArgs = ['-msse', '-shared', '-lboost_python-mt-py27']
+LinkArgs = ['-msse', '-shared', '-lboost_python']
 
 def mkExtension(name):
     modname = '_' + name.lower()


### PR DESCRIPTION
Installing boost using "sudo apt-get install libboost-all-dev" or "sudo apt-get install libboost-python-dev" takes care of all internal symbolic links. Thus, one don't have to define the python version (former 26) and we should quit the "mt" flag for new updated versions of boost (launchpad code).
